### PR TITLE
Added a GetAtlas method

### DIFF
--- a/glue/gluespineentity.monkey
+++ b/glue/gluespineentity.monkey
@@ -516,6 +516,10 @@ Class SpineEntity
 		Return skeleton.B
 	End
 	
+	Method GetAtlas:SpineAtlas()
+		Return atlas
+	End
+
 	'skin api
 	Method SetSkin:Void(name:String)
 		' --- change the skin ---


### PR DESCRIPTION
This will allow several SpineEntites share the same Atlas, if the next ones are loaded with the same Atlas the first one was created. This can make it easier to get a single texture for several characters, by creating the new ones line New SpineEntity("another_skeleton.json", PreviousEntity.GetAtlas())
I find it useful so I supose others may find it useful too.
