### PR TITLE
Added support for scaled atlas

### DIFF
--- a/glue/spineentity.monkey
+++ b/glue/spineentity.monkey
@@ -18,6 +18,9 @@ Class SpineEntity
 	Field skeleton:SpineSkeleton
 	
 	Private
+
+	Field atlasScale:Float
+
 	Field callback:SpineEntityCallback
 	
 	Field animation:SpineAnimation
@@ -562,9 +565,9 @@ Class SpineEntity
 					
 					'render
 					If snapToPixels
-						region.RendererObject.Draw(Int(slotWorldX[index]), Int(slotWorldY[index]), slotWorldRotation[index], slotWorldScaleX[index], slotWorldScaleY[index])
+						region.RendererObject.Draw(Int(slotWorldX[index]), Int(slotWorldY[index]), slotWorldRotation[index], slotWorldScaleX[index], slotWorldScaleY[index], Self.atlasScale)
 					Else
-						region.RendererObject.Draw(slotWorldX[index], slotWorldY[index], slotWorldRotation[index], slotWorldScaleX[index], slotWorldScaleY[index])
+						region.RendererObject.Draw(slotWorldX[index], slotWorldY[index], slotWorldRotation[index], slotWorldScaleX[index], slotWorldScaleY[index], Self.atlasScale)
 					EndIf
 					
 				Case SpineAttachmentType.SkinnedMesh
@@ -2285,5 +2288,10 @@ Class SpineEntity
 	Method SetCallback:Void(callback:SpineEntityCallback)
 		' --- change the callback ---
 		Self.callback = callback
+	End
+
+	Method SetAtlasScale:Void( value:Float )
+		' --- manually set scale for scaled atlas ---
+		Self.atlasScale = 1.0 / value
 	End
 End

--- a/glue/spinerendererobject.monkey
+++ b/glue/spinerendererobject.monkey
@@ -11,5 +11,5 @@ Interface SpineRendererObject
 	
 	'Method Draw:Void(x:Float, y:Float)
 	Method Draw:Void(verts:Float[])
-	Method Draw:Void(x:Float, y:Float, angle:Float, scaleX:Float, scaleY:Float)
+	Method Draw:Void(x:Float, y:Float, angle:Float, scaleX:Float, scaleY:Float, atlasScale:Float)
 End

--- a/spinemojo/spinemojorendererobject.monkey
+++ b/spinemojo/spinemojorendererobject.monkey
@@ -53,15 +53,15 @@ Class SpineMojoRendererObject Implements SpineRendererObject
 		#EndIf
 	End
 	
-	Method Draw:Void(x:Float, y:Float, angle:Float, scaleX:Float, scaleY:Float)
+	Method Draw:Void(x:Float, y:Float, angle:Float, scaleX:Float, scaleY:Float, atlasScale:Float)
 		#If SPINE_ATLAS_ROTATE
 		If rotate
-			DrawImage(image, x, y, angle - 90, scaleX, scaleY, 0)
+			DrawImage(image, x, y, angle - 90, scaleX * atlasScale, scaleY * atlasScale, 0)
 		Else
-			DrawImage(image, x, y, angle, scaleX, scaleY, 0)
+			DrawImage(image, x, y, angle, scaleX * atlasScale, scaleY * atlasScale, 0)
 		EndIf
 		#Else
-		DrawImage(image, x, y, angle, scaleX, scaleY, 0)
+		DrawImage(image, x, y, angle, scaleX * atlasScale, scaleY * atlasScale, 0)
 		#EndIf
 	End
 End


### PR DESCRIPTION
I added support for scaled atlas, in the following case:

captura
(https://cloud.githubusercontent.com/assets/7415055/4988478/6bd46f80-6944-11e4-8b51-5b6391d62d6d.png)

I use " Self.animation.SetAtlasScale( 0.12 ) " to tell the scale i used on atlas.
